### PR TITLE
First returns null on empty results

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -221,7 +221,12 @@ class Result implements ArrayAccess, Iterator {
      * @return Model
      */
     public function first() {
-        return $this->offsetGet(0);
+        if ($this->offsetExists(0)) {
+            return $this->offsetGet(0);
+        } else {
+            trigger_error('Can not get null of empty result set', E_USER_WARNING);
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
On null result set, ->first() will return null and trigger a warning …
